### PR TITLE
Do not compile header files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,17 @@ all:
 
 linux : 
 		@echo 'Building Decrypt0r for Linux...'
-		@$(CC) src/decrypt0r.c src/firmware_tools.c src/firmware_tools.h -o decrypt0r
+		@$(CC) src/decrypt0r.c src/firmware_tools.c -o decrypt0r
 		@echo 'Succesfully built Decrypt0r for Linux'
 
 macos : 
 		@echo 'Building Decrypt0r for OS X...'
-		@$(CC) src/decrypt0r.c src/firmware_tools.c src/firmware_tools.h -o decrypt0r
+		@$(CC) src/decrypt0r.c src/firmware_tools.c -o decrypt0r
 		@echo 'Succesfully built Decrypt0r for OS X'
 
 iOS : 	
 		@echo 'Building Decrypt0r for iOS...'
-		@xcrun -sdk iphoneos clang --sysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk src/decrypt0r.c src/firmware_tools.c src/firmware_tools.h -arch armv7 -framework IOKit -framework CoreFoundation -Wall -miphoneos-version-min=6.0
+		@xcrun -sdk iphoneos clang --sysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk src/decrypt0r.c src/firmware_tools.c -arch armv7 -framework IOKit -framework CoreFoundation -Wall -miphoneos-version-min=6.0
 		@mv a.out decrypt0r
 		@echo 'Succesfully built Decrypt0r for iOS'
 


### PR DESCRIPTION
Hi, 
thank you for your awesome work to make decrypting iOS firmware easier. I just found that you are compiling also header files which is useless and can result in an error as:
clang: error: cannot specify -o when generating multiple output files
This patch fix the mistake.
